### PR TITLE
fix: address azuread deprecations and testing papercuts

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -27,6 +27,6 @@ locals {
 
   tags = merge(local._tags, var.tags)
 
-  azuread_application = var.azuread_application == null ? azuread_application.stacklet_application[0] : data.azuread_application.stacklet_application[0]
+  azuread_application       = var.azuread_application == null ? azuread_application.stacklet_application[0] : data.azuread_application.stacklet_application[0]
   azuread_service_principal = var.azuread_application == null ? azuread_service_principal.stacklet_sp[0] : data.azuread_service_principal.stacklet_sp[0]
 }

--- a/locals.tf
+++ b/locals.tf
@@ -17,7 +17,7 @@
 locals {
   object_id   = azurerm_user_assigned_identity.stacklet_identity.principal_id
   app_role_id = var.azuread_application == null ? random_uuid.app_role_uuid.id : data.azuread_application.stacklet_application[0].app_role_ids.AssumeRoleWithWebIdentity
-  resource_id = local.azuread_service_principal.id
+  resource_id = local.azuread_service_principal.object_id
 
   audience = "api://stacklet/provider/azure/${var.prefix}"
 

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "azurerm_user_assigned_identity" "stacklet_identity" {
 }
 
 resource "azuread_application" "stacklet_application" {
-  count = var.azuread_application == null ? 1 : 0
+  count           = var.azuread_application == null ? 1 : 0
   display_name    = "${var.prefix}-application"
   identifier_uris = [local.audience]
   owners = [
@@ -63,12 +63,12 @@ resource "azuread_application" "stacklet_application" {
 }
 
 data "azuread_application" "stacklet_application" {
-  count = var.azuread_application == null ? 0 : 1
+  count        = var.azuread_application == null ? 0 : 1
   display_name = var.azuread_application
 }
 
 resource "azuread_service_principal" "stacklet_sp" {
-  count = var.azuread_application == null ? 1 : 0
+  count                        = var.azuread_application == null ? 1 : 0
   client_id                    = local.azuread_application.client_id
   app_role_assignment_required = true
   owners = [
@@ -81,7 +81,7 @@ resource "azuread_service_principal" "stacklet_sp" {
 }
 
 data "azuread_service_principal" "stacklet_sp" {
-  count = var.azuread_application == null ? 0 : 1
+  count        = var.azuread_application == null ? 0 : 1
   display_name = var.azuread_application
 }
 

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ data "azuread_application" "stacklet_application" {
 
 resource "azuread_service_principal" "stacklet_sp" {
   count = var.azuread_application == null ? 1 : 0
-  application_id               = local.azuread_application.application_id
+  client_id                    = local.azuread_application.client_id
   app_role_assignment_required = true
   owners = [
     data.azuread_client_config.current.object_id,

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,7 @@ policy execution within your subscription.
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+[Azure Functions Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) must be installed.
 
 ## Providers
 

--- a/vars.tf
+++ b/vars.tf
@@ -17,6 +17,10 @@
 variable "prefix" {
   type        = string
   description = "A Prefix for all of the generated resources"
+  validation {
+    condition     = can(regex("^[a-z0-9]+$", var.prefix))
+    error_message = "Prefix should contain only numbers and lowercase letters"
+  }
 }
 
 variable "resource_group_location" {

--- a/vars.tf
+++ b/vars.tf
@@ -83,7 +83,7 @@ variable "event_names" {
 }
 
 variable "azuread_application" {
-  type = string
+  type        = string
   description = "Azure AD Application. One per tenant."
-  default = null
+  default     = null
 }


### PR DESCRIPTION
There are 2 main functional changes/fixes here:

- Reference `azuread_service_principal.object_id` rather than `azuread_service_principal.id` so our local provisioner's role assignment call can succeed.
- Switch from `application_id` attributes/arguments to `client_id` in light of the upstream provider's [deprecations](https://github.com/hashicorp/terraform-provider-azuread/pull/1214).

Then a couple additions to address papercuts I hit during testing:

- We depend on [Azure Functions Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?) but didn't seem to call that out anywhere.
- If we try using a `prefix` with anything but numbers and lowercase letters, the apply can fail because of naming restrictions on the `azurerm_storage_account` resource. May as well move that validation earlier (or normalize it in the storage account resource, but that feels suboptimal).

The extra changes come from a `terraform fmt -recursive` pass. More detail in the individual commits below in case it's helpful.