### PR TITLE
feat: add an explicit input for the target deployment prefix

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -19,7 +19,7 @@ locals {
   app_role_id = var.azuread_application == null ? random_uuid.app_role_uuid.id : data.azuread_application.stacklet_application[0].app_role_ids.AssumeRoleWithWebIdentity
   resource_id = local.azuread_service_principal.object_id
 
-  audience = "api://stacklet/provider/azure/${var.prefix}"
+  audience = "api://stacklet/provider/azure/${var.aws_target_prefix}"
 
   _tags = {
     "stacklet:app" : "Azure Relay"

--- a/readme.md
+++ b/readme.md
@@ -58,6 +58,7 @@ No modules.
 | <a name="input_aws_target_account"></a> [aws\_target\_account](#input\_aws\_target\_account) | AWS Target account for relay, to be provided by Stacklet. | `string` | n/a | yes |
 | <a name="input_aws_target_event_bus"></a> [aws\_target\_event\_bus](#input\_aws\_target\_event\_bus) | AWS Target event bus for relay, to be provided by Stacklet. | `string` | n/a | yes |
 | <a name="input_aws_target_partition"></a> [aws\_target\_partition](#input\_aws\_target\_partition) | AWS Target partition for relay, to be provided by Stacklet. | `string` | `"aws"` | no |
+| <a name="input_aws_target_prefix"></a> [aws\_target\_prefix](#input\_aws\_target\_prefix) | Deployment prefix for the target Stacklet instance, to be provided by Stacklet. | `string` | n/a | yes |
 | <a name="input_aws_target_region"></a> [aws\_target\_region](#input\_aws\_target\_region) | AWS Target region for relay, to be provided by Stacklet. | `string` | n/a | yes |
 | <a name="input_aws_target_role_name"></a> [aws\_target\_role\_name](#input\_aws\_target\_role\_name) | AWS Target role name for relay, to be provided by Stacklet. | `string` | n/a | yes |
 | <a name="input_azuread_application"></a> [azuread\_application](#input\_azuread\_application) | Azure AD Application. One per tenant. | `string` | `null` | no |

--- a/vars.tf
+++ b/vars.tf
@@ -66,6 +66,11 @@ variable "aws_target_event_bus" {
   description = "AWS Target event bus for relay, to be provided by Stacklet."
 }
 
+variable "aws_target_prefix" {
+  type        = string
+  description = "Deployment prefix for the target Stacklet instance, to be provided by Stacklet."
+}
+
 variable "tags" {
   type        = map(any)
   description = "Tags to apply to resources"


### PR DESCRIPTION
Add an `aws_target_prefix` input variable, which must match the deployment prefix associated with a target Stacklet instance. This allows the existing `prefix` variable to keep its intended use - a chunk of text that will be prepended to resource names.

Modify `local.audience` so that it incorporates `aws_target_prefix` rather than `prefix`. As far as I can tell the remaining uses of `prefix` are fine as-is.

-----

Without this change, the deployed function app fails with errors like the following unless `prefix` matches the Stacklet deployment prefix:

```
[Warning]   DefaultAzureCredential failed to retrieve a token from the included credentials.
Attempted credentials:
    ManagedIdentityCredential: (None) An unexpected error occured while fetching the AAD Token.
Code: None
Message: An unexpected error occured while fetching the AAD Token.
To mitigate this issue, please refer to the troubleshooting guidelines here at https://aka.ms/azsdk/python/identity/defaultazurecredential/troubleshoot.
```

That can be worked around by redeploying this module with a `prefix` that matches Stacklet, but:

1. That's a pretty nuclear option
2. Using the Stacklet deployment prefix for `prefix` is typically not useful in a customer environment