### PR TITLE
chore: add .github/CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @stacklet/engineering


### PR DESCRIPTION
### what

Add a .github/CODEOWNERS file

### why

So the default reviewer makes sense

### testing

Github validates the file as part of the PR

### docs

N/A