### PR TITLE
chore: update api audience url

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,7 +17,7 @@
 locals {
   app_role_id = var.azuread_application == null ? random_uuid.app_role_uuid.id : data.azuread_application.stacklet_application[0].app_role_ids.AssumeRoleWithWebIdentity
 
-  audience = "api://stacklet/provider/azure/${var.aws_target_prefix}"
+  audience = "api://${data.azuread_client_config.current.tenant_id}/stacklet/provider/azure/${var.aws_target_prefix}"
 
   _tags = {
     "stacklet:app" : "Azure Relay"


### PR DESCRIPTION
[ENG-5692](https://stacklet.atlassian.net/browse/ENG-5692)

### what

Changes the audience URI format to be in line with Azure's recent [restrictions](https://learn.microsoft.com/en-us/entra/identity-platform/identifier-uri-restrictions).

### why

The prior URI format is no longer accepted for new applications.

### testing

Tested in sandbox environments.

### docs

N/A
