### PR TITLE
feat: make vnet address space configurable

### DIFF
--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -1,0 +1,7 @@
+formatter: markdown
+
+output:
+  file: README.md
+
+settings:
+  lockfile: false

--- a/README.md
+++ b/README.md
@@ -49,16 +49,20 @@ This system enables:
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-[Azure Functions Core Tools](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local) must be installed.
+| Name | Version |
+|------|---------|
+| <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >=2.8.0 |
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.56.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >=2.8.0 |
 | <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
-| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | n/a |
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.56.0 |
 | <a name="provider_local"></a> [local](#provider\_local) | n/a |
-| <a name="provider_null"></a> [null](#provider\_null) | n/a |
 | <a name="provider_random"></a> [random](#provider\_random) | n/a |
 
 ## Modules
@@ -69,22 +73,41 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [azapi_resource.stacklet_queue](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/resource) | resource |
+| [azapi_update_resource.stacklet_function_network](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azapi_update_resource.stacklet_storage_network](https://registry.terraform.io/providers/azure/azapi/latest/docs/resources/update_resource) | resource |
+| [azuread_app_role_assignment.stacklet_app_role_assignment](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/app_role_assignment) | resource |
 | [azuread_application.stacklet_application](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/application) | resource |
 | [azuread_service_principal.stacklet_sp](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/resources/service_principal) | resource |
 | [azurerm_application_insights.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/application_insights) | resource |
 | [azurerm_eventgrid_system_topic.azure_rm_events](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventgrid_system_topic) | resource |
 | [azurerm_eventgrid_system_topic_event_subscription.azure_rm_event_subscription](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/eventgrid_system_topic_event_subscription) | resource |
 | [azurerm_linux_function_app.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/linux_function_app) | resource |
+| [azurerm_private_dns_zone.storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone.storage_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_dns_zone_virtual_network_link.storage_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_dns_zone_virtual_network_link) | resource |
+| [azurerm_private_endpoint.stacklet_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.stacklet_storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
+| [azurerm_private_endpoint.stacklet_storage_table](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/private_endpoint) | resource |
 | [azurerm_resource_group.stacklet_rg](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/resource_group) | resource |
+| [azurerm_role_assignment.function_storage_account](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.function_storage_blob](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_assignment.function_storage_queue](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
 | [azurerm_service_plan.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/service_plan) | resource |
 | [azurerm_storage_account.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_account) | resource |
-| [azurerm_storage_queue.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/storage_queue) | resource |
+| [azurerm_subnet.stacklet_function](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
+| [azurerm_subnet.stacklet_private_endpoints](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/subnet) | resource |
 | [azurerm_user_assigned_identity.stacklet_identity](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/user_assigned_identity) | resource |
+| [azurerm_virtual_network.stacklet](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_network) | resource |
+| [local_file.function_app_versioned](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.function_json](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
-| [null_resource.function_deploy](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
-| [null_resource.stacklet](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
+| [local_file.host_json](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [random_string.storage_account_suffix](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_uuid.app_role_uuid](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [archive_file.function_app](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
 | [azuread_application.stacklet_application](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application) | data source |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.stacklet_sp](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
@@ -107,9 +130,14 @@ No modules.
 | <a name="input_event_grid_topic_name"></a> [event\_grid\_topic\_name](#input\_event\_grid\_topic\_name) | System Topic Name for subscription events if it already exists | `string` | `null` | no |
 | <a name="input_event_grid_topic_resource_group"></a> [event\_grid\_topic\_resource\_group](#input\_event\_grid\_topic\_resource\_group) | System Topic resource group name for subscription events if it already exists | `string` | `null` | no |
 | <a name="input_event_names"></a> [event\_names](#input\_event\_names) | Event Names to filter | `list(string)` | <pre>[<br/>  "Microsoft.Resources.ResourceWriteSuccess",<br/>  "Microsoft.Resources.ResourceActionSuccess",<br/>  "Microsoft.Resources.ResourceDeleteSuccess"<br/>]</pre> | no |
+| <a name="input_force_delete_resource_group"></a> [force\_delete\_resource\_group](#input\_force\_delete\_resource\_group) | Force delete the resource group when terraform destroy is run | `bool` | `false` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A Prefix for all of the generated resources | `string` | n/a | yes |
-| <a name="input_resource_group_location"></a> [resource\_group\_location](#input\_resource\_group\_location) | Resource Group location for generated resources | `string` | n/a | yes |
+| <a name="input_resource_group_location"></a> [resource\_group\_location](#input\_resource\_group\_location) | Resource Group location for generated resources | `string` | `"East US"` | no |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource Group name for generated resources | `string` | `null` | no |
+| <a name="input_subnet_prefix_length"></a> [subnet\_prefix\_length](#input\_subnet\_prefix\_length) | The network prefix size used for virtual network subnets | `string` | `24` | no |
+| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID. This could also be set using the ARM\_SUBSCRIPTION\_ID environment variable. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(any)` | `{}` | no |
+| <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the relay's virtual network | `string` | `"10.0.0.0/16"` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -51,19 +51,24 @@ This system enables:
 
 | Name | Version |
 |------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | ~> 1.0 |
+| <a name="requirement_archive"></a> [archive](#requirement\_archive) | >=2.7.1 |
 | <a name="requirement_azapi"></a> [azapi](#requirement\_azapi) | >=2.8.0 |
+| <a name="requirement_azuread"></a> [azuread](#requirement\_azuread) | >=3.7.0 |
 | <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | >=4.56.0 |
+| <a name="requirement_local"></a> [local](#requirement\_local) | >=2.6.2 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.8.1 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | >=2.7.1 |
 | <a name="provider_azapi"></a> [azapi](#provider\_azapi) | >=2.8.0 |
-| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | n/a |
+| <a name="provider_azuread"></a> [azuread](#provider\_azuread) | >=3.7.0 |
 | <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | >=4.56.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+| <a name="provider_local"></a> [local](#provider\_local) | >=2.6.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | >=3.8.1 |
 
 ## Modules
 
@@ -111,9 +116,7 @@ No modules.
 | [azuread_application.stacklet_application](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/application) | data source |
 | [azuread_client_config.current](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/client_config) | data source |
 | [azuread_service_principal.stacklet_sp](https://registry.terraform.io/providers/hashicorp/azuread/latest/docs/data-sources/service_principal) | data source |
-| [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_eventgrid_system_topic.azure_rm_events](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/eventgrid_system_topic) | data source |
-| [azurerm_role_definition.builtin](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/role_definition) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs

--- a/function.tf
+++ b/function.tf
@@ -162,6 +162,10 @@ resource "azurerm_linux_function_app" "stacklet" {
     ignore_changes = [
       tags["hidden-link: /app-insights-resource-id"]
     ]
+
+    replace_triggered_by = [
+      azurerm_virtual_network.stacklet.address_space
+    ]
   }
 }
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,20 @@
+_:
+    @just --list --unsorted
+
+# format terraform files
+format:
+    terraform fmt -recursive
+
+# lint files
+lint:
+    #!/usr/bin/env bash
+    set -e
+
+    terraform fmt -recursive --check
+    terraform init
+    terraform validate
+    tflint -f compact --recursive
+
+# update module documentation in README
+docs:
+    terraform-docs .

--- a/main.tf
+++ b/main.tf
@@ -14,16 +14,9 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-data "azurerm_client_config" "current" {}
-
 data "azuread_client_config" "current" {}
 
 data "azurerm_subscription" "current" {}
-
-
-data "azurerm_role_definition" "builtin" {
-  name = "Contributor"
-}
 
 resource "random_uuid" "app_role_uuid" {}
 

--- a/network.tf
+++ b/network.tf
@@ -44,6 +44,12 @@ resource "azurerm_subnet" "stacklet_function" {
       actions = ["Microsoft.Network/virtualNetworks/subnets/action"]
     }
   }
+
+  lifecycle {
+    replace_triggered_by = [
+      azurerm_virtual_network.stacklet.address_space
+    ]
+  }
 }
 
 resource "azurerm_subnet" "stacklet_private_endpoints" {
@@ -54,4 +60,10 @@ resource "azurerm_subnet" "stacklet_private_endpoints" {
 
   # Enable service endpoint for Storage
   service_endpoints = ["Microsoft.Storage"]
+
+  lifecycle {
+    replace_triggered_by = [
+      azurerm_virtual_network.stacklet.address_space
+    ]
+  }
 }

--- a/network.tf
+++ b/network.tf
@@ -14,9 +14,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+locals {
+  vnet_mask      = tonumber(split("/", var.vnet_address_space)[1])
+  subnet_newbits = var.subnet_prefix_length - local.vnet_mask
+}
+
 resource "azurerm_virtual_network" "stacklet" {
   name                = "${var.prefix}-vnet"
-  address_space       = ["10.0.0.0/16"]
+  address_space       = [var.vnet_address_space]
   location            = azurerm_resource_group.stacklet_rg.location
   resource_group_name = azurerm_resource_group.stacklet_rg.name
   tags                = local.tags
@@ -26,7 +31,7 @@ resource "azurerm_subnet" "stacklet_function" {
   name                 = "${var.prefix}-function-subnet"
   resource_group_name  = azurerm_resource_group.stacklet_rg.name
   virtual_network_name = azurerm_virtual_network.stacklet.name
-  address_prefixes     = ["10.0.1.0/24"]
+  address_prefixes     = [cidrsubnet(var.vnet_address_space, local.subnet_newbits, 1)]
 
   # Enable service endpoint for Storage to allow access to Storage Account
   service_endpoints = ["Microsoft.Storage"]
@@ -45,7 +50,7 @@ resource "azurerm_subnet" "stacklet_private_endpoints" {
   name                 = "${var.prefix}-pe-subnet"
   resource_group_name  = azurerm_resource_group.stacklet_rg.name
   virtual_network_name = azurerm_virtual_network.stacklet.name
-  address_prefixes     = ["10.0.2.0/24"]
+  address_prefixes     = [cidrsubnet(var.vnet_address_space, local.subnet_newbits, 2)]
 
   # Enable service endpoint for Storage
   service_endpoints = ["Microsoft.Storage"]

--- a/provider.tf
+++ b/provider.tf
@@ -27,7 +27,24 @@ terraform {
       source  = "azure/azapi"
       version = ">=2.8.0"
     }
+    local = {
+      source  = "hashicorp/local"
+      version = ">=2.6.2"
+    }
+    azuread = {
+      source  = "hashicorp/azuread"
+      version = ">=3.7.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">=3.8.1"
+    }
+    archive = {
+      source  = "hashicorp/archive"
+      version = ">=2.7.1"
+    }
   }
+  required_version = "~> 1.0"
 }
 
 provider "azurerm" {

--- a/vars.tf
+++ b/vars.tf
@@ -111,3 +111,25 @@ variable "azuread_application" {
   description = "Azure AD Application. One per tenant."
   default     = null
 }
+
+variable "vnet_address_space" {
+  type        = string
+  description = "Address space for the relay's virtual network"
+  default     = "10.0.0.0/16"
+
+  validation {
+    condition     = can(cidrnetmask(var.vnet_address_space))
+    error_message = "Address space must be a valid network range (such as 10.0.0.0/16)"
+  }
+}
+
+variable "subnet_prefix_length" {
+  type        = string
+  description = "The network prefix size used for virtual network subnets"
+  default     = 24
+
+  validation {
+    condition     = var.subnet_prefix_length > local.vnet_mask + 1 && var.subnet_prefix_length <= 28
+    error_message = "The subnet mask must be between ${local.vnet_mask + 2} and 28"
+  }
+}


### PR DESCRIPTION
[Freshdesk #1423](https://stacklet.freshdesk.com/a/tickets/1423)

### what

#### Core change

- Expose variables to control the vnet address space and subnet size

#### Follow-up changes

- Add lifecycle configuration options to replace subnets & function app when changing a vnet address space
- Regenerate module docs
- Add terraform-docs config and a justfile based on https://github.com/stacklet/terraform-gcp-stacklet-relay/blob/17ef77e55e0d775353db38154f2a8c8bbd04dcd1/justfile to make some tidying tasks easier
- Address tflint feedback

### why

The default address space overlapped with vnets in a customer environment and led to confusion

### testing

Tested in my sandbox subscription, confirmed that changes took effect and the relay module functioned afterward

<img width="831" height="367" alt="image" src="https://github.com/user-attachments/assets/08e22dc8-69bd-426b-bc98-fc234d6fa595" />


### docs

Doc updates are included here
