### PR TITLE
chore: add CI pipeline and pre-commit checks

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    commit-message:
+      prefix: chore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+permissions: {}
+
+jobs:
+  Lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set tool versions
+        uses: wistia/parse-tool-versions@32f568a4ffd4bfa7720ebf93f171597d1ebc979a # v2.1.1
+        with:
+          postfix: _TOOL_VERSION
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4.0.0
+        with:
+          terraform_version: ${{ env.TERRAFORM_TOOL_VERSION }}
+
+      - name: Setup TFLint
+        uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6.2.2
+        with:
+          tflint_version: ${{ env.TFLINT_TOOL_VERSION }}
+
+      - name: Run pre-commit checks
+        uses: j178/prek-action@53276d8b0d10f8b6672aa85b4588c6921d0370cc # v2.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,22 @@
+repos:
+  - repo: https://github.com/antonbabenko/pre-commit-terraform
+    rev: d0e12caebb2ab0ee8bf98181c8bfe9702bca103d  # frozen: v1.105.0
+    hooks:
+      - id: terraform_fmt
+      - id: terraform_validate
+      - id: terraform_tflint
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: 393031adb9afb225ee52ae2ccd7a5af5525e03e8  # frozen: v1.7.11
+    hooks:
+      - id: actionlint
+
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: ea2eb407b4cbce87cf0d502f36578950494f5ac9  # frozen: v1.23.1
+    hooks:
+    - id: zizmor
+
+  - repo: https://github.com/codespell-project/codespell
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # frozen: v2.4.2
+    hooks:
+      - id: codespell

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,5 @@
+just 1.40.0
+terraform 1.13.5
+terraform-docs 0.20.0
+tflint v0.61.0
+uv 0.8.14

--- a/justfile
+++ b/justfile
@@ -7,13 +7,7 @@ format:
 
 # lint files
 lint:
-    #!/usr/bin/env bash
-    set -e
-
-    terraform fmt -recursive --check
-    terraform init
-    terraform validate
-    tflint -f compact --recursive
+    uvx prek run --all-files
 
 # update module documentation in README
 docs:


### PR DESCRIPTION
### what

- Add `.github/workflows/ci.yml` running pre-commit hooks on push/PR
  to main with pinned action SHAs and least-privilege permissions
- Add `.pre-commit-config.yaml` with hooks for `terraform fmt`,
  `terraform validate`, `terraform_tflint`, `actionlint`, `zizmor`,
  and `codespell`; all revisions frozen to specific SHAs
- Add `.github/dependabot.yaml` for monthly grouped GitHub Actions
  dependency updates with a 7-day cooldown
- Add `.tool-versions` pinning `just`, `terraform`, `terraform-docs`,
  `tflint`, and `uv`
- Simplify `justfile` `lint` target to delegate to `uvx prek run
  --all-files` instead of inline bash

### why

Introduces automated linting and formatting enforcement via CI so
issues are caught on every push and pull request. Pinned SHAs and
dependabot automation follow supply-chain security best practices.

### testing

CI workflow runs on this branch; pre-commit hooks can be exercised
locally with `just lint`.

### docs

No docs needed.

---------------------------

🤖 Generated with [Claude Code](https://claude.com/claude-code)