### PR TITLE
chore: remove inline provider blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,18 @@ This system enables:
 ## Provider Configuration
 
 This module does not configure providers. The calling module must configure
-`azurerm`, `azapi`, and `azuread` providers and pass them to the module.
+`azurerm` and `azapi` providers with the target subscription. The `azuread`
+provider is configured automatically from your Azure credentials.
 
-The `subscription_id` previously accepted as a module input is now set
-directly on the `azurerm` and `azapi` provider blocks in the calling module.
+Credentials are sourced from the standard Azure authentication chain.
+For local use, authenticate via `az login`. For automated deployments,
+supply credentials via environment variables (`ARM_CLIENT_ID`,
+`ARM_CLIENT_SECRET`, `ARM_TENANT_ID`) or by setting `client_id`,
+`client_secret`, and `tenant_id` directly on your provider blocks.
 
-The `force_delete_resource_group` variable has also been removed. To allow
-deletion of a non-empty resource group, set
-`prevent_deletion_if_contains_resources = false` in the `features {}` block
-of your `azurerm` provider.
+### Standalone deployment
 
-Example:
+The common case — deploying the relay directly into a single subscription:
 
 ```hcl
 provider "azurerm" {
@@ -71,15 +72,48 @@ provider "azapi" {
   subscription_id = "your-subscription-id"
 }
 
-provider "azuread" {}
+module "azure_relay" {
+  source = "github.com/stacklet/terraform-azure-stacklet-relay?ref=<sha>"
+
+  prefix               = "your-prefix"
+  aws_target_account   = "123456789012"
+  aws_target_region    = "us-east-1"
+  aws_target_role_name = "your-prefix-azure-relay"
+  aws_target_event_bus = "your-prefix-azure-relay"
+  aws_target_prefix    = "your-prefix"
+}
+```
+
+### Embedded in a larger root module
+
+If your root module manages multiple Azure subscriptions simultaneously
+(e.g. a management subscription and a workload subscription), use provider
+aliases and pass them explicitly via `providers`:
+
+```hcl
+provider "azurerm" {
+  features {}
+  subscription_id = "management-subscription-id"
+}
+
+provider "azurerm" {
+  alias           = "workload"
+  features {}
+  subscription_id = "workload-subscription-id"
+}
+
+provider "azapi" {
+  alias           = "workload"
+  subscription_id = "workload-subscription-id"
+}
 
 module "azure_relay" {
   source = "github.com/stacklet/terraform-azure-stacklet-relay?ref=<sha>"
 
   providers = {
-    azurerm = azurerm
+    azurerm = azurerm.workload
     azuread = azuread
-    azapi   = azapi
+    azapi   = azapi.workload
   }
 
   prefix               = "your-prefix"
@@ -90,6 +124,23 @@ module "azure_relay" {
   aws_target_prefix    = "your-prefix"
 }
 ```
+
+## Migrating from a previous version
+
+The following breaking changes were made to align with Terraform's
+recommended practice of not declaring provider configurations in reusable
+modules:
+
+- `subscription_id` input variable removed — set `subscription_id` directly
+  on your `azurerm` and `azapi` provider blocks instead
+- `force_delete_resource_group` input variable removed — to allow deletion
+  of a non-empty resource group, set
+  `prevent_deletion_if_contains_resources = false` in the `features {}` block
+  of your `azurerm` provider
+
+No changes to deployed infrastructure are required. On your next
+`terraform plan` after updating the module SHA you should see 0 resource
+changes.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -46,6 +46,51 @@ This system enables:
 - **Automated governance actions** - Automated remediation and policy enforcement
 - **Cross-cloud resource visibility** - Unified governance across Azure and AWS
 
+## Provider Configuration
+
+This module does not configure providers. The calling module must configure
+`azurerm`, `azapi`, and `azuread` providers and pass them to the module.
+
+The `subscription_id` previously accepted as a module input is now set
+directly on the `azurerm` and `azapi` provider blocks in the calling module.
+
+The `force_delete_resource_group` variable has also been removed. To allow
+deletion of a non-empty resource group, set
+`prevent_deletion_if_contains_resources = false` in the `features {}` block
+of your `azurerm` provider.
+
+Example:
+
+```hcl
+provider "azurerm" {
+  features {}
+  subscription_id = "your-subscription-id"
+}
+
+provider "azapi" {
+  subscription_id = "your-subscription-id"
+}
+
+provider "azuread" {}
+
+module "azure_relay" {
+  source = "github.com/stacklet/terraform-azure-stacklet-relay?ref=<sha>"
+
+  providers = {
+    azurerm = azurerm
+    azuread = azuread
+    azapi   = azapi
+  }
+
+  prefix               = "your-prefix"
+  aws_target_account   = "123456789012"
+  aws_target_region    = "us-east-1"
+  aws_target_role_name = "your-prefix-azure-relay"
+  aws_target_event_bus = "your-prefix-azure-relay"
+  aws_target_prefix    = "your-prefix"
+}
+```
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
@@ -133,12 +178,10 @@ No modules.
 | <a name="input_event_grid_topic_name"></a> [event\_grid\_topic\_name](#input\_event\_grid\_topic\_name) | System Topic Name for subscription events if it already exists | `string` | `null` | no |
 | <a name="input_event_grid_topic_resource_group"></a> [event\_grid\_topic\_resource\_group](#input\_event\_grid\_topic\_resource\_group) | System Topic resource group name for subscription events if it already exists | `string` | `null` | no |
 | <a name="input_event_names"></a> [event\_names](#input\_event\_names) | Event Names to filter | `list(string)` | <pre>[<br/>  "Microsoft.Resources.ResourceWriteSuccess",<br/>  "Microsoft.Resources.ResourceActionSuccess",<br/>  "Microsoft.Resources.ResourceDeleteSuccess"<br/>]</pre> | no |
-| <a name="input_force_delete_resource_group"></a> [force\_delete\_resource\_group](#input\_force\_delete\_resource\_group) | Force delete the resource group when terraform destroy is run | `bool` | `false` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | A Prefix for all of the generated resources | `string` | n/a | yes |
 | <a name="input_resource_group_location"></a> [resource\_group\_location](#input\_resource\_group\_location) | Resource Group location for generated resources | `string` | `"East US"` | no |
 | <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | Resource Group name for generated resources | `string` | `null` | no |
 | <a name="input_subnet_prefix_length"></a> [subnet\_prefix\_length](#input\_subnet\_prefix\_length) | The network prefix size used for virtual network subnets | `string` | `24` | no |
-| <a name="input_subscription_id"></a> [subscription\_id](#input\_subscription\_id) | Azure subscription ID. This could also be set using the ARM\_SUBSCRIPTION\_ID environment variable. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags to apply to resources | `map(any)` | `{}` | no |
 | <a name="input_vnet_address_space"></a> [vnet\_address\_space](#input\_vnet\_address\_space) | Address space for the relay's virtual network | `string` | `"10.0.0.0/16"` | no |
 

--- a/provider.tf
+++ b/provider.tf
@@ -47,16 +47,4 @@ terraform {
   required_version = "~> 1.0"
 }
 
-provider "azurerm" {
-  features {
-    resource_group {
-      prevent_deletion_if_contains_resources = !var.force_delete_resource_group
-    }
-  }
 
-  subscription_id = var.subscription_id
-}
-
-provider "azapi" {
-  subscription_id = var.subscription_id
-}

--- a/vars.tf
+++ b/vars.tf
@@ -14,12 +14,6 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-variable "subscription_id" {
-  type        = string
-  description = "Azure subscription ID. This could also be set using the ARM_SUBSCRIPTION_ID environment variable."
-  default     = null
-}
-
 variable "prefix" {
   type        = string
   description = "A Prefix for all of the generated resources"
@@ -39,12 +33,6 @@ variable "resource_group_location" {
   type        = string
   description = "Resource Group location for generated resources"
   default     = "East US"
-}
-
-variable "force_delete_resource_group" {
-  type        = bool
-  description = "Force delete the resource group when terraform destroy is run"
-  default     = false
 }
 
 variable "event_grid_topic_name" {


### PR DESCRIPTION
[ENG-7559](https://stacklet.atlassian.net/browse/ENG-7559)

### what

- Removed provider "azurerm" and provider "azapi" inline blocks from provider.tf — the module now follows Terraform's recommended practice of not declaring provider  configurations in reusable modules                                                                                                                                            
- Removed subscription_id and force_delete_resource_group input variables, which were only used by the deleted provider blocks                                                
- Updated README with a Provider Configuration section covering both standalone and embedded (multi subscription) deployment scenarios, credential options, and a migration  guide for existing users 

### why

Inline provider blocks in a reusable module prevent callers from overriding or aliasing providers via providers = {}. This blocked embedding the module within a root module that manages multiple Azure subscriptions simultaneously.  A similar change was made to the GCP relay provider in the recent past.

### testing

- Module was deployed to the test environment via imp-manifests referencing commit 19c472ef on this branch                                                                 
- terraform plan produced the expected  resources with 0 errors
- Provider aliasing (azurerm.<deployment>, azapi.<deployment>) passed through correctly to the module  


### docs

README updated with:                                                                                                                                                        
  - Standalone deployment example (including required_providers block)
  - Embedded/multi-subscription example with provider aliases and resource_provider_registrations = "none" guidance                                                             
  - Migration section covering all three breaking changes and confirming no infrastructure changes required on plan if the only change is upgrading to this version.

[ENG-7559]: https://stacklet.atlassian.net/browse/ENG-7559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ